### PR TITLE
Ignore empty value when validating user IDs

### DIFF
--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -617,6 +617,8 @@ class ChatGPTTelegramBot:
         if self.is_group_chat(update):
             admin_user_ids = self.config['admin_user_ids'].split(',')
             for user in itertools.chain(allowed_user_ids, admin_user_ids):
+                if not user.strip():
+                    continue
                 if await self.is_user_in_group(update, context, user):
                     logging.info(f'{user} is a member. Allowing group chat message...')
                     return True
@@ -702,6 +704,8 @@ class ChatGPTTelegramBot:
         if self.is_group_chat(update):
             admin_user_ids = self.config['admin_user_ids'].split(',')
             for user in itertools.chain(allowed_user_ids, admin_user_ids):
+                if not user.strip():
+                    continue
                 if await self.is_user_in_group(update, context, user):
                     if 'guests' not in self.usage:
                         self.usage['guests'] = UsageTracker('guests', 'all guest users in group chats')


### PR DESCRIPTION
Fix an edge case in which `ALLOWED_TELEGRAM_USER_IDS` is set to an empty string (allow only admin and all members of groups one of the admins joined).